### PR TITLE
shop: 페이지네이션 그룹화기능

### DIFF
--- a/src/views/shop/shop.html
+++ b/src/views/shop/shop.html
@@ -62,6 +62,8 @@
 
   </main>
   <footer class="footer"></footer>
+  <script type="module" src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.esm.js"></script>
+  <script nomodule src="https://unpkg.com/ionicons@5.5.2/dist/ionicons/ionicons.js"></script>
 </body>
 
 </html>

--- a/src/views/shop/shop.js
+++ b/src/views/shop/shop.js
@@ -67,14 +67,82 @@ async function productByCategory() {
 
       // 카테고리별 상품조회 api
       const datas = await Api.getNoToken('/api/categories/products', e.target.id);
-      console.log('확인확인',e.target, datas)
       showProducts(datas.data, e.target.id);
       searchInput.value = '';
     };
   }
 }
+// 페이지 네이션 함수
+function renderPagination(currentPage, totalPage, categoryId, keyword) { //4 4
+  // if(currentPage === totalPage) return 
+  var pageCount = 2
+  var pageGroup = Math.ceil(currentPage / pageCount); // 2
+
+  var last = pageGroup * pageCount; //6
+  if (last > totalPage) last = totalPage; 
+  var first = last - (pageCount - 1) <= 0 ? 1 : last - (pageCount - 1); //4
+  var next = last + 1; //5
+  var prev = first - 1; //1
+  if(currentPage === totalPage) {
+    first = last;
+  }
+  // debugger
+  
+  const fragmentPage = document.createDocumentFragment();
+  // if (_totalCount <= 10) return;
+  if (prev > 0) {
+    var preli = document.createElement('li');
+      preli.insertAdjacentHTML("beforeend", `<a class="pagination-link" id='prev'>&lt;</a>`);
+      fragmentPage.appendChild(preli);
+  }
+	// console.log(first, last)
+  // debugger
+  for (let i = first; i <= last; i++) {
+    
+    const li = document.createElement("li");
+    li.insertAdjacentHTML("beforeend", `<a class="pageNum pagination-link" id=${i} aria-label="Goto page ${i}">${i}</a>`);
+    fragmentPage.appendChild(li);
+  }
+
+  if (last < totalPage) {
+    var endli = document.createElement('li');
+    endli.insertAdjacentHTML("beforeend", `<a class="pagination-link" id='next'>&gt;</a>`);
+
+    fragmentPage.appendChild(endli);
+  }
+
+  getNode('.pagination-list').appendChild(fragmentPage);
+  
+  // 페이지 목록 생성
+  // debugger
+  // const buttons = getNode('.pagination-list')
+  const pageBtn = document.querySelectorAll('.pagination-link');
+  // console.log(pageBtn)
+  for (let j=0; j<pageBtn.length; j++) {
+    pageBtn[j].addEventListener("click",(e)=> {
+      console.log(e.target.getAttribute("id"));
+      let idName = e.target.getAttribute("id");
+      if(idName === "next")  {
+        getNode('.pagination-list').innerHTML="";
+        renderPagination(next, totalPage)
+        showProductByPage(next)
+      } else if(idName === "prev") {
+        getNode('.pagination-list').innerHTML="";
+        renderPagination(1, totalPage)
+        showProductByPage(1)
+      }
+    })
+  }
+  function showProductByPage (page) {
+    if (categoryId === "검색") return getProductSearch(page, keyword);
+    else if (categoryId !== '') return getProductCategory(page, categoryId);
+    else return getProductAll(page);
+  }
+  
+};
 // 전체 상품조회하기 => 인자 api 통신을 받은 데이터, 카테고리명, 검색 키워드
-function showProducts(data, categoryId = '', keyword = '') {
+function showProducts(data, categoryId = '', keyword = '', page = 1) {
+  
   const productList = getNode('#product-list');
   productList.innerHTML = "";
   data.products.map((product) => {
@@ -90,25 +158,27 @@ function showProducts(data, categoryId = '', keyword = '') {
   // 페이지네이션 
   const pagenationList = getNode('.pagination-list');
   pagenationList.innerHTML = "";
-  for (let i = 1; i <= data.totalPage; i++) {
-    pagenationList.innerHTML += `<li><a class="pagination-link" aria-label="Goto page ${i}">${i}</a></li>`;
-  }
+  renderPagination(page, data.totalPage, categoryId, keyword);
+  // for (let i = 1; i <= data.totalPage; i++) {
+  //   pagenationList.innerHTML += `<li><a class="pagination-link" aria-label="Goto page ${i}">${i}</a></li>`;
+  // }
+  
   // 페이지 네이션 링크 
-  const pagenationLink = document.querySelectorAll('.pagination-link');
+  const pageNum = document.querySelectorAll('.pageNum');
   for (let i = 0; i < data.totalPage; i++) {
     // 전체보기가 아닐떄 
     // 카테고리 id 값으로 
     if (categoryId === '검색') {
-      pagenationLink[i].addEventListener("click", () => {
-        getProductSearch(i + 1, keyword);
+      pageNum[i].addEventListener("click", (e) => {
+        getProductSearch(e.target.getAttribute("id"), keyword);
       });
     } else if (categoryId !== '') {
-      pagenationLink[i].addEventListener("click", () => {
-        getProductCategory(i + 1, categoryId);
+      pageNum[i].addEventListener("click", (e) => {
+        getProductCategory(e.target.getAttribute("id"), categoryId);
       });
     } else {
-      pagenationLink[i].addEventListener("click", () => {
-        getProductAll(i + 1);
+      pageNum[i].addEventListener("click", (e) => {
+        getProductAll(e.target.getAttribute("id"));
       });
     }
   }
@@ -117,21 +187,21 @@ function showProducts(data, categoryId = '', keyword = '') {
 async function getProductSearch(page, keyword) {
   const datas = await fetch(`/api/search?keyword=${keyword}&page=${page}`);
   const data = await datas.json();
-  showProducts(data.data, '검색', keyword);
+  showProducts(data.data, '검색', keyword, page);
+  
 }
 
 // 카테고리별 상품목록 + 페이네이션 하기- Api.get 통신
 async function getProductCategory(page, categoryName) {
   const datas = await fetch(`/api/categories/products/${categoryName}?page=${page}`);
   const data = await datas.json();
-  showProducts(data.data, categoryName);
+  showProducts(data.data, categoryName , "",page);
 }
 // 전체보기 상품목록 + 페이지네이션 - Api.get 통신
 async function getProductAll(page) {
   const datas = await fetch(`/api/products?page=${page}`);
   const data = await datas.json();
-  console.log(data);
-  showProducts(data.data);
+  showProducts(data.data, "", "", page); 
 }
 
 function addAllEvents() {


### PR DESCRIPTION
- 데이터가 많아지면 페이지 네이션 버튼도 계속 커지므로 그룹화 기능 구현
- 테스트 위해 2페이지씩 그룹핑
  - 추후에 데이터 보충시 5페이지씩 그룹핑예정
 <hr>

📍 수정 및 논의 부분 <br>
- 활성화된 페이지 css로 변화주기 
- 이전, 다음 버튼 클릭시 맨앞or 맨뒤로 갈것인지 아니면 바로 직전페이지로 갈것인지 
  - 현재는 이전페이지 클릭시 => 맨 앞의 페이지로 이동(1페이지)/ 다음페이지 클릭스 => 다음 페이지 그룹의 맨앞 페이지로 이동 
  